### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,12 @@
       {
         "url": "https://api.surveymonkey.net/v3/.*",
         "methods": ["GET", "POST", "PATCH"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "api_key": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request makes a configuration update to the `manifest.json` file, enhancing how API keys are injected into outgoing requests to the SurveyMonkey API.

API key injection improvement:

* Added a `settingsInjection` block to the SurveyMonkey API configuration, specifying that the `api_key` should be included in the `Authorization` header for requests.